### PR TITLE
Removed redundant argument "$?"

### DIFF
--- a/main/bash-modules/README
+++ b/main/bash-modules/README
@@ -7,7 +7,7 @@ Home page: https://github.com/vlisivka/bash-modules/
 
 Usage:
 
-. import.sh module[...] || exit $?
+. import.sh module[...] || exit
 
 Bash modules should work OK wih -u (nounset) and -e (errexit) shell
 options. It is good idea to always use "set -ueo pipefail" in your own


### PR DESCRIPTION
`exit` and `exit  $?` are equivalent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vlisivka/bash-modules/11)
<!-- Reviewable:end -->
